### PR TITLE
Fix: Prevent crash when using timeline

### DIFF
--- a/src/components/Row.js
+++ b/src/components/Row.js
@@ -224,7 +224,7 @@ function Row({
               </div>
             </div>
 
-            {UNKNOWN_DISTRICT_KEY in data.districts && (
+            {data.districts && UNKNOWN_DISTRICT_KEY in data.districts && (
               <div className="state-meta-bottom">
                 <div className={classnames('disclaimer')}>
                   <AlertIcon />
@@ -265,7 +265,7 @@ function Row({
       )}
 
       {showDistricts &&
-        Object.keys(data.districts)
+        Object.keys(data.districts || {})
           .sort((a, b) => sortingFunction(a, b))
           .map((districtName) => (
             <DistrictRow


### PR DESCRIPTION
Fixes crash which used to happen if we go to a date before 26th April
with one of the state rows expanded.

**Description of PR**

A brief description of what changes your PR introduces. The better this description, the quicker we can review, exchange feedback, and merge!

**Relevant Issues**  
Fixes #...

**Checklist**

- [ ] Compiles and passes lint tests
- [ ] Properly formatted
- [ ] Tested on desktop
- [ ] Tested on phone

**Screenshots**

Add relevant screenshots here
